### PR TITLE
Backport ISSUE-213: POJOs are changed to be backward compatible

### DIFF
--- a/common-auth/pom.xml
+++ b/common-auth/pom.xml
@@ -47,6 +47,12 @@
             <artifactId>hadoop-minikdc</artifactId>
             <version>2.7.3</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.directory.jdbm</groupId>
+                    <artifactId>apacheds-jdbm1</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>

--- a/schema-registry/client/src/main/java/com/hortonworks/registries/schemaregistry/client/HeaderRequestFilter.java
+++ b/schema-registry/client/src/main/java/com/hortonworks/registries/schemaregistry/client/HeaderRequestFilter.java
@@ -1,0 +1,14 @@
+package com.hortonworks.registries.schemaregistry.client;
+
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientRequestFilter;
+import javax.ws.rs.ext.Provider;
+import java.io.IOException;
+
+@Provider
+public class HeaderRequestFilter implements ClientRequestFilter {
+    @Override
+    public void filter(ClientRequestContext requestContext) throws IOException {
+        requestContext.getHeaders().add("X-Registry-Client-Version", "0.3.0.4-fts");
+    }
+}

--- a/schema-registry/common/src/main/java/com/hortonworks/registries/schemaregistry/AggregatedSchemaMetadataInfo.java
+++ b/schema-registry/common/src/main/java/com/hortonworks/registries/schemaregistry/AggregatedSchemaMetadataInfo.java
@@ -17,12 +17,15 @@
  */
 package com.hortonworks.registries.schemaregistry;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import java.io.Serializable;
 import java.util.Collection;
 
 /**
  * This class represents aggregated information about schema metadata which includes versions and mapped serdes.
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class AggregatedSchemaMetadataInfo implements Serializable {
 
     private static final long serialVersionUID = -414992394022547720L;

--- a/schema-registry/common/src/main/java/com/hortonworks/registries/schemaregistry/CompatibilityResult.java
+++ b/schema-registry/common/src/main/java/com/hortonworks/registries/schemaregistry/CompatibilityResult.java
@@ -15,11 +15,14 @@
  **/
 package com.hortonworks.registries.schemaregistry;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import java.io.Serializable;
 
 /**
  *
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public final class CompatibilityResult implements Serializable {
     public static final CompatibilityResult SUCCESS = new CompatibilityResult(true, null);
 

--- a/schema-registry/common/src/main/java/com/hortonworks/registries/schemaregistry/ConfigEntry.java
+++ b/schema-registry/common/src/main/java/com/hortonworks/registries/schemaregistry/ConfigEntry.java
@@ -27,6 +27,8 @@ import java.util.Collections;
  */
 public final class ConfigEntry<T> implements Serializable {
 
+    private static final long serialVersionUID = -3408548579276359761L;
+
     private final String name;
     private final Class<? extends T> type;
     private final String description;

--- a/schema-registry/common/src/main/java/com/hortonworks/registries/schemaregistry/SchemaFieldInfo.java
+++ b/schema-registry/common/src/main/java/com/hortonworks/registries/schemaregistry/SchemaFieldInfo.java
@@ -15,12 +15,17 @@
  **/
 package com.hortonworks.registries.schemaregistry;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import java.io.Serializable;
 
 /**
  *
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class SchemaFieldInfo implements Serializable {
+    private static final long serialVersionUID = -6194661942575334254L;
+
     public static final String ID = "id";
     public static final String SCHEMA_INSTANCE_ID = "schemaInstanceId";
     public static final String TIMESTAMP = "timestamp";

--- a/schema-registry/common/src/main/java/com/hortonworks/registries/schemaregistry/SchemaIdVersion.java
+++ b/schema-registry/common/src/main/java/com/hortonworks/registries/schemaregistry/SchemaIdVersion.java
@@ -15,6 +15,7 @@
  **/
 package com.hortonworks.registries.schemaregistry;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.google.common.base.Preconditions;
 
 import java.io.Serializable;
@@ -25,6 +26,7 @@ import java.io.Serializable;
  *
  * It is not necessary that all fields are always available but the minimum information to find schema version is available.
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public final class SchemaIdVersion implements Serializable {
     private static final long serialVersionUID = 6081264497288914406L;
 

--- a/schema-registry/common/src/main/java/com/hortonworks/registries/schemaregistry/SchemaMetadata.java
+++ b/schema-registry/common/src/main/java/com/hortonworks/registries/schemaregistry/SchemaMetadata.java
@@ -15,6 +15,7 @@
  **/
 package com.hortonworks.registries.schemaregistry;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 
@@ -24,6 +25,7 @@ import java.io.Serializable;
 /**
  * This class is about metadata of a schema which includes name, type, schemaGroup, description, compatibility and evolve.
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class SchemaMetadata implements Serializable {
 
     private static final long serialVersionUID = -6880986623123299254L;

--- a/schema-registry/common/src/main/java/com/hortonworks/registries/schemaregistry/SchemaMetadataInfo.java
+++ b/schema-registry/common/src/main/java/com/hortonworks/registries/schemaregistry/SchemaMetadataInfo.java
@@ -15,6 +15,7 @@
  **/
 package com.hortonworks.registries.schemaregistry;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.google.common.base.Preconditions;
 
 import java.io.Serializable;
@@ -24,7 +25,10 @@ import java.io.Serializable;
  * There can be only one instance with the same name.
  * New versions of the schema can be registered for the given {@link SchemaMetadataInfo} by giving {@link SchemaVersion} instances.
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public final class SchemaMetadataInfo implements Serializable {
+
+    private static final long serialVersionUID = 8083699103887496439L;
 
     /**
      * metadata about the schema

--- a/schema-registry/common/src/main/java/com/hortonworks/registries/schemaregistry/SchemaVersion.java
+++ b/schema-registry/common/src/main/java/com/hortonworks/registries/schemaregistry/SchemaVersion.java
@@ -15,12 +15,17 @@
  **/
 package com.hortonworks.registries.schemaregistry;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import java.io.Serializable;
 
 /**
  * This class represents details about versioned instance of a schema which includes description and schema text.
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class SchemaVersion implements Serializable {
+    private static final long serialVersionUID = 1664618495690787804L;
+
     private String description;
     private String schemaText;
 

--- a/schema-registry/common/src/main/java/com/hortonworks/registries/schemaregistry/SchemaVersionInfo.java
+++ b/schema-registry/common/src/main/java/com/hortonworks/registries/schemaregistry/SchemaVersionInfo.java
@@ -15,12 +15,17 @@
  **/
 package com.hortonworks.registries.schemaregistry;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import java.io.Serializable;
 
 /**
  *
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public final class SchemaVersionInfo implements Serializable {
+
+    private static final long serialVersionUID = -669711262227194948L;
 
     /**
      * global unique id of this schema instance

--- a/schema-registry/common/src/main/java/com/hortonworks/registries/schemaregistry/SchemaVersionKey.java
+++ b/schema-registry/common/src/main/java/com/hortonworks/registries/schemaregistry/SchemaVersionKey.java
@@ -15,6 +15,7 @@
  **/
 package com.hortonworks.registries.schemaregistry;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.google.common.base.Preconditions;
 
 import java.io.Serializable;
@@ -22,6 +23,7 @@ import java.io.Serializable;
 /**
  * This class contains schema name and version.
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public final class SchemaVersionKey implements Serializable {
 
     private static final long serialVersionUID = 1779747592974345866L;

--- a/schema-registry/common/src/main/java/com/hortonworks/registries/schemaregistry/SerDesInfo.java
+++ b/schema-registry/common/src/main/java/com/hortonworks/registries/schemaregistry/SerDesInfo.java
@@ -15,6 +15,7 @@
  **/
 package com.hortonworks.registries.schemaregistry;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.google.common.base.Preconditions;
 
 import java.io.Serializable;
@@ -22,7 +23,10 @@ import java.io.Serializable;
 /**
  *
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class SerDesInfo implements Serializable {
+    private static final long serialVersionUID = -3756866955883733874L;
+
     private Long id;
     private Long timestamp;
     private SerDesPair serDesPair;

--- a/schema-registry/common/src/main/java/com/hortonworks/registries/schemaregistry/SerDesPair.java
+++ b/schema-registry/common/src/main/java/com/hortonworks/registries/schemaregistry/SerDesPair.java
@@ -17,12 +17,17 @@
  */
 package com.hortonworks.registries.schemaregistry;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import java.io.Serializable;
 
 /**
  *
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class SerDesPair implements Serializable {
+    private static final long serialVersionUID = -1291992612139840722L;
+
     private String name;
     private String description;
     private String fileId;

--- a/schema-registry/common/src/main/java/com/hortonworks/registries/schemaregistry/avro/AvroSchemaProvider.java
+++ b/schema-registry/common/src/main/java/com/hortonworks/registries/schemaregistry/avro/AvroSchemaProvider.java
@@ -23,7 +23,6 @@ import com.hortonworks.registries.schemaregistry.SchemaFieldInfo;
 import com.hortonworks.registries.schemaregistry.errors.InvalidSchemaException;
 import com.hortonworks.registries.schemaregistry.errors.SchemaNotFoundException;
 import org.apache.avro.Schema;
-import org.codehaus.jackson.JsonNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -182,7 +181,7 @@ public class AvroSchemaProvider extends AbstractSchemaProvider {
                     appendable.append("{\"name\":\"").append(field.name()).append("\"").append(",\"type\":");
 
                     // handle default value
-                    JsonNode defaultValue = field.defaultValue();
+                    Object defaultValue = field.defaultVal();
                     if (defaultValue != null) {
                         appendable.append(defaultValue.toString());
                     }

--- a/schema-registry/common/src/main/java/com/hortonworks/registries/schemaregistry/avro/AvroSchemaResolver.java
+++ b/schema-registry/common/src/main/java/com/hortonworks/registries/schemaregistry/avro/AvroSchemaResolver.java
@@ -23,8 +23,8 @@ import com.hortonworks.registries.schemaregistry.SchemaVersionRetriever;
 import com.hortonworks.registries.schemaregistry.errors.CyclicSchemaDependencyException;
 import com.hortonworks.registries.schemaregistry.errors.InvalidSchemaException;
 import com.hortonworks.registries.schemaregistry.errors.SchemaNotFoundException;
+import org.apache.avro.JsonProperties;
 import org.apache.avro.Schema;
-import org.codehaus.jackson.node.NullNode;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -171,7 +171,7 @@ public class AvroSchemaResolver implements SchemaResolver {
                 Schema.Field rebuiltField = new Schema.Field(field.name(),
                                                    fieldSchema,
                                                    field.doc(),
-                                                   currentFieldTypeIsUnion ? NullNode.getInstance() : field.defaultValue(),
+                                                   currentFieldTypeIsUnion ? JsonProperties.NULL_VALUE : field.defaultVal(),
                                                    field.order());
                 for (Map.Entry<String, Object> prop : field.getObjectProps().entrySet()) {
                     rebuiltField.addProp(prop.getKey(), prop.getValue());
@@ -185,44 +185,13 @@ public class AvroSchemaResolver implements SchemaResolver {
                 for (String alias : schema.getAliases()) {
                     updatedRootSchema.addAlias(alias);
                 }
-                for (Map.Entry<String, org.codehaus.jackson.JsonNode> nodeEntry : schema.getJsonProps().entrySet()) {
-                    updatedRootSchema.addProp(nodeEntry.getKey(), nodeEntry.getValue());
+                for (Map.Entry<String, Object> prop : schema.getObjectProps().entrySet()) {
+                    updatedRootSchema.addProp(prop.getKey(), prop.getValue());
                 }
             }
         }
 
         return updatedRootSchema;
-    }
-
-    private Schema updateUnionFields(Schema schema) {
-        Schema updatedSchema = schema;
-        List<Schema.Field> fields = schema.getFields();
-        boolean hasUnionType = false;
-        List<Schema.Field> updatedFields = new ArrayList<>(fields.size());
-        for (Schema.Field field : fields) {
-            Schema fieldSchema = field.schema();
-            Schema.Field updatedField = field;
-            // if it is union and first type is null then set default value as null
-            if (fieldSchema.getType() == Schema.Type.UNION &&
-                    fieldSchema.getTypes().get(0).getType() == Schema.Type.NULL) {
-                updatedField = new Schema.Field(field.name(), fieldSchema, field.doc(), NullNode.getInstance(), field.order());
-                hasUnionType = true;
-            }
-            updatedFields.add(updatedField);
-        }
-
-        if (hasUnionType) {
-            updatedSchema = Schema.createRecord(schema.getName(), schema.getDoc(), schema.getNamespace(), schema.isError());
-            updatedSchema.setFields(updatedFields);
-            for (String alias : schema.getAliases()) {
-                updatedSchema.addAlias(alias);
-            }
-            for (Map.Entry<String, org.codehaus.jackson.JsonNode> nodeEntry : schema.getJsonProps().entrySet()) {
-                updatedSchema.addProp(nodeEntry.getKey(), nodeEntry.getValue());
-            }
-        }
-
-        return updatedSchema;
     }
 
     private Map<String, Schema> traverseIncludedSchemaTypes(String schemaText,

--- a/schema-registry/common/src/main/java/com/hortonworks/registries/schemaregistry/avro/AvroSchemaValidator.java
+++ b/schema-registry/common/src/main/java/com/hortonworks/registries/schemaregistry/avro/AvroSchemaValidator.java
@@ -499,7 +499,7 @@ public final class AvroSchemaValidator implements SchemaValidator<Schema> {
                 if (writerField == null) {
                     // Reader field does not correspond to any field in the writer
                     // record schema, so the reader field must have a default value.
-                    if (readerField.defaultValue() == null) {
+                    if (readerField.defaultVal() == null) {
                         if(!isUnionWithFirstTypeAsNull(readerFieldSchema)) {
                             // reader field has no default value
                             String message = String.format("Reader schema missing default value for field: %s", readerField.name());

--- a/storage/core/src/main/java/com/hortonworks/registries/storage/search/OrderBy.java
+++ b/storage/core/src/main/java/com/hortonworks/registries/storage/search/OrderBy.java
@@ -17,12 +17,17 @@
  */
 package com.hortonworks.registries.storage.search;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import java.io.Serializable;
 
 /**
  *
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class OrderBy implements Serializable {
+    private static final long serialVersionUID = 8220102056152801315L;
+
     private String fieldName;
     private boolean asc;
 

--- a/storage/core/src/main/java/com/hortonworks/registries/storage/search/Predicate.java
+++ b/storage/core/src/main/java/com/hortonworks/registries/storage/search/Predicate.java
@@ -17,12 +17,17 @@
  */
 package com.hortonworks.registries.storage.search;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import java.io.Serializable;
 
 /**
  *
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Predicate implements Serializable {
+    private static final long serialVersionUID = 3928533466168563000L;
+
     public enum Operation {EQ, LT, GT, LTE, GTE, CONTAINS}
 
     private String field;

--- a/storage/core/src/main/java/com/hortonworks/registries/storage/search/PredicateCombinerPair.java
+++ b/storage/core/src/main/java/com/hortonworks/registries/storage/search/PredicateCombinerPair.java
@@ -17,12 +17,16 @@
  */
 package com.hortonworks.registries.storage.search;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import java.io.Serializable;
 
 /**
  *
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class PredicateCombinerPair implements Serializable {
+    private static final long serialVersionUID = 8860616526693470116L;
     private Predicate predicate;
     private WhereClauseCombiner.Operation combinerOperation;
 

--- a/storage/core/src/main/java/com/hortonworks/registries/storage/search/SearchQuery.java
+++ b/storage/core/src/main/java/com/hortonworks/registries/storage/search/SearchQuery.java
@@ -17,6 +17,8 @@
  */
 package com.hortonworks.registries.storage.search;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Collections;
@@ -25,7 +27,9 @@ import java.util.List;
 /**
  *
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class SearchQuery implements Serializable {
+    private static final long serialVersionUID = 3394075873934901992L;
     private String nameSpace;
     private List<OrderBy> orderByFields;
     private WhereClause whereClause;

--- a/storage/core/src/main/java/com/hortonworks/registries/storage/search/WhereClause.java
+++ b/storage/core/src/main/java/com/hortonworks/registries/storage/search/WhereClause.java
@@ -17,6 +17,8 @@
  */
 package com.hortonworks.registries.storage.search;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -35,7 +37,10 @@ import java.util.List;
  *
  *
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class WhereClause implements Serializable {
+    private static final long serialVersionUID = 901279529557954101L;
+
     protected List<PredicateCombinerPair> predicateCombinerPairs;
 
     private WhereClause() {


### PR DESCRIPTION
This is to enable us to upgrade the schema registry client and server. These changes will

1. Add a header indicating the version to client requests
2. Make the client POJOs compatible with server 0.7.0, although this branch is based on 0.3.0

The plan is to upgrade all clients to be on this patched version, which we can check by ensuring all requests to the registry server include this header, then upgrade the servers in all environments to 0.7.0, and finally get rid of this fork and get all clients onto 0.7.0